### PR TITLE
MyFruit.center does not exist before using update

### DIFF
--- a/continuous_domain/catcher.py
+++ b/continuous_domain/catcher.py
@@ -104,6 +104,9 @@ class MyFruit():
 
         self.grid_width = grid_width
         self.grid_height = grid_height
+        
+        # Force to get a self.center (valid)
+        self.reset()
 
         """
         Defines ranges where the fruit can pop


### PR DESCRIPTION
MyFruit.center does not exist before using update once => error if observe the continuous catcher without having even called update on it.
Reset can also be used to init correctly the center of the fruit.