### PR TITLE
Reset of the fruit is off

### DIFF
--- a/continuous_domain/catcher.py
+++ b/continuous_domain/catcher.py
@@ -141,7 +141,7 @@ class MyFruit():
             according to ranges defined by inner variables.
         """
         a, b = np.random.random((2,))
-        x = np.floor(a * (self.grid_width - self.size[0]))
+        x = np.floor((a * (self.grid_width - self.size[0])) + self.size[0] / 2.0) 
         y = np.floor(b * ((self.grid_height - self.size[1]) / 2.0))
 
         self.center = (x, -1 * y)


### PR DESCRIPTION
The center of the fruit can be inside [0, grid_width - fruit_widht] but it should be between [fruit_width / 2.0, grid_width - fruit_width / 2.0].

Currently if the fruit is placed below fruit_width / 2.0, it will be outside the screen.
Currently if the fruit is placed at the maximum to the right (grid_width - fruit_width), it will no touch the screen border.