### PR TITLE
Collision is broken

### DIFF
--- a/continuous_domain/catcher.py
+++ b/continuous_domain/catcher.py
@@ -224,11 +224,14 @@ class ContinuousCatcher():
         w1, h1 = self.bar.size
         w2, h2 = self.fruit.size
 
+        l1x, l1y = x1 - w1 / 2.0, y1 - h1 / 2.0
+        l2x, l2y = x2 - w2 / 2.0, y2 - h2 / 2.0
+
         return (
-            y1 < y2 + h2 and
-            y2 < y1 + h1 and
-            x1 < x2 + w2 and
-            x2 < x1 + w1)
+                l1y < l2y + h2 and
+                l2y < l1y + h1 and
+                l1x < l2x + w2 and
+                l2x < l1x + w1)
 
     def step(self, act):
         """


### PR DESCRIPTION
If the fruit_x + fruit_width < bar_x then it cannot collide even if this is possible.

To test, set fruit_x (in reset()) to fruit_size_x / 2.0 and put the bar as far as possible to the left (towards 0)

This is due to the fact that x1 and x2 (resp. y1 and y2) are not the coordinates of a corner but the ones from the center